### PR TITLE
update sync workflow to rebuild every 4 hours

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,6 +1,6 @@
 on:
   schedule:
-    - cron: '30 00,4,12,16,20 * * *'  # rebuild daily at 4:30 UTC
+    - cron: '30 00,4,8,12,16,20 * * *'  # sync every 4 hours
   workflow_dispatch:
 
 name: sync


### PR DESCRIPTION
I have added a rebuild at 8:30 that appeared to be missing from the sync workflow.