### PR TITLE
fix: remove duplicate repositories and add case-insensitive comparison in workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -40,10 +40,11 @@ jobs:
           repos=$(jq -r '.plugins[].host' plugin-repository.json | \
               grep '^https://github.com/' | \
               sed 's|https://github.com/||' | \
+              tr '[:upper:]' '[:lower:]' | \
               sort -u)
 
           # Read existing known repositories (excluding empty lines and comments)
-          existing=$(grep -v '^#' known-repositories.txt | grep -v '^[[:space:]]*$' | sort -u)
+          existing=$(grep -v '^#' known-repositories.txt | grep -v '^[[:space:]]*$' | tr '[:upper:]' '[:lower:]' | sort -u)
 
           # Find new repositories (those in plugin-repository.json but not in known-repositories.txt)
           new_repos=$(comm -23 <(echo "$repos") <(echo "$existing"))

--- a/justfile
+++ b/justfile
@@ -62,9 +62,10 @@ update-known-repos:
     repos=$(jq -r '.plugins[].host' plugin-repository.json | \
         grep '^https://github.com/' | \
         sed 's|https://github.com/||' | \
+        tr '[:upper:]' '[:lower:]' | \
         sort -u)
     # Read existing known repositories (excluding empty lines and comments)
-    existing=$(grep -v '^#' known-repositories.txt | grep -v '^[[:space:]]*$' | sort -u)
+    existing=$(grep -v '^#' known-repositories.txt | grep -v '^[[:space:]]*$' | tr '[:upper:]' '[:lower:]' | sort -u)
     # Find new repositories (those in plugin-repository.json but not in known-repositories.txt)
     new_repos=$(comm -23 <(echo "$repos") <(echo "$existing"))
     # Append new repositories if any were found

--- a/known-repositories.txt
+++ b/known-repositories.txt
@@ -55,7 +55,6 @@ cisco-talos/dyndataresolver
 cisco-talos/ghida
 coldzer0/ida-for-delphi
 danielplohmann/idascope
-danigargu/dereferencing
 danigargu/heap-viewer
 danigargu/idatropy
 danigargu/syms2elf
@@ -192,20 +191,6 @@ rand-tech/idaplugins
 
 # added 2025-11-29
 XingTuLab/recopilot
-
-# Discovered on 2025-11-29 08:42:25
-KasperskyLab/hrtng
-
-# Discovered on 2025-12-03 08:46:05
-AzzOnFire/emuit
-JusticeRage/Gepetto
-
-# Discovered on 2025-12-09 08:46:47
-AzzOnFire/yarka
-VirusTotal/vt-ida-plugin
-
-# Discovered on 2025-12-12 04:47:05
-HexRaysSA/ida-terminal-plugin
 
 # manually added 2025-12-13
 p05wn/SuperHint


### PR DESCRIPTION
## Problem

The `known-repositories.txt` file contains duplicate entries that differ only in case. This happens because:

1. Repositories are manually added in lowercase (e.g., `virustotal/vt-ida-plugin`)
2. The workflow script uses `comm -23` which is case-sensitive
3. When `plugin-repository.json` contains the canonical GitHub casing from plugin metadata (e.g., `VirusTotal/vt-ida-plugin`), it's detected as a "new" repository and appended

## Changes

### 1. Data cleanup - removed duplicates

| Original | Duplicate removed |
|----------|-------------------|
| `danigargu/dereferencing` | `danigargu/deREferencing` |
| `kasperskylab/hrtng` | `KasperskyLab/hrtng` |
| `azzonfire/emuit` | `AzzOnFire/emuit` |
| `justicerage/gepetto` | `JusticeRage/Gepetto` |
| `azzonfire/yarka` | `AzzOnFire/yarka` |
| `virustotal/vt-ida-plugin` | `VirusTotal/vt-ida-plugin` |
| `hexrayssa/ida-terminal-plugin` | `HexRaysSA/ida-terminal-plugin` |

### 2. Workflow fix - case-insensitive comparison

Added `tr '[:upper:]' '[:lower:]'` to normalize both the extracted repos from JSON and existing repos from TXT before comparison, preventing future duplicates.

## Related

Root cause is also being addressed in HexRaysSA/ida-hcli#130, which adds case-insensitive normalization to the indexer itself.