### PR TITLE
chore: Register libtero and 19h IDA tools in known repositories

### DIFF
--- a/known-repositories.txt
+++ b/known-repositories.txt
@@ -215,3 +215,11 @@ milankovo/decode_instruction
 
 # manually added 2026-01-09
 SymbioticSec/ida-security-scanner
+libtero/suture
+libtero/graphviewer
+libtero/idaguides
+19h/ida-lifter
+19h/ida-codedump
+19h/ida-semray
+19h/idalib-dump
+19h/chernobog


### PR DESCRIPTION
known-repositories.txt (modified):
- Added three repositories from user libtero: suture, graphviewer, and idaguides
- Added four repositories from user 19h: ida-lifter, ida-codedump, ida-semray, idalib-dump, chernobog

Impact:
- Expands the tracking list to include additional IDA Pro related utilities, specifically focusing on lifting, dumping, debofuscation, and graph visualization tools.

---

Note: @libtero's graphviewer and my idalib-dump and chernobog don't have an ida-plugin json yet, I'll add them very soon though.