### PR TITLE
Request for adding HappyIDA plugin

### DIFF
--- a/known-repositories.txt
+++ b/known-repositories.txt
@@ -11,6 +11,7 @@ williballenthin/ida-settings
 HexRaysSA/ida-cyberchef
 milankovo/zydisinfo
 danigargu/deREferencing
+HappyIDA/HappyIDA
 
 # this is an initial list of plugins from plugins.hex-rays.com on Nov 17, 2025:
 0rganizers/nmips


### PR DESCRIPTION
Hi,

We’d like to participate in the IDA Plugin Contest, but our plugin wasn’t picked up by the plugin repository scanner.

We tested hcli plugin install https://github.com/HappyIDA/HappyIDA, and it worked. We’d like to submit the plugin by opening a pull request.