### PR TITLE
Request for adding DeepExtractIDA plugin

### DIFF
--- a/known-repositories.txt
+++ b/known-repositories.txt
@@ -12,6 +12,7 @@ HexRaysSA/ida-cyberchef
 milankovo/zydisinfo
 danigargu/deREferencing
 HappyIDA/HappyIDA
+marcosd4h/DeepExtractIDA
 
 # this is an initial list of plugins from plugins.hex-rays.com on Nov 17, 2025:
 0rganizers/nmips


### PR DESCRIPTION
Hi Hex-Rays team,

I’d like to participate in the IDA Plugin Contest, but my plugin repository wasn’t picked up by the scanner yet. 

I’ve validated the package locally with hcli plugin install against:
https://github.com/marcosd4h/DeepExtractIDA

DeepExtract is an IDA plugin that extracts PE binaries into structured SQLite databases and AI-ready C++ source files, capturing metadata, decompiled code, cross-references, vtable hierarchies, and dangerous API calls. DeepExtract helps to power autonomous vulnerability discovery agents, grounds manual code review in tools like Claude Code and Cursor with clean decompiled code, and enables enterprise-scale threat hunting across thousands of executables.

Thanks for your consideration!