### PR TITLE
Fix/EA-762 cap ida versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,30 +82,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Merge plugins
-        env:
-          # Hex-Rays portal API key, used only to read the IDA download catalog
-          # (`hcli download --list-tags`) so idaVersions can be capped at the
-          # latest released IDA (EA-762). hcli authenticates from this env var
-          # automatically. If the secret is unset/invalid the derivation yields
-          # nothing and merge_plugins.py falls back to its built-in default —
-          # the build never fails on this.
-          HCLI_API_KEY: ${{ secrets.HCLI_API_KEY }}
-          HCLI_DISABLE_UPDATES: 1
+        # EA-762: idaVersions are capped at the latest released IDA via
+        # merge_plugins.py's LATEST_RELEASED_IDA. Override with the env var when a
+        # new IDA ships (e.g. LATEST_RELEASED_IDA: "9.5") — no auth/secret needed.
         run: |
           mkdir -p ./public/plugins/
-
-          # EA-762: derive the latest released IDA from the hcli download catalog.
-          # Keeps only numeric ida-pro:X.Y[spN] tags (excludes betas / ida-pro:latest
-          # / OS-suffixed dupes) and takes the max.
-          latest=$(uvx --from ida-hcli hcli --disable-updates download --list-tags 2>/dev/null \
-            | grep -oE 'ida-pro:[0-9]+\.[0-9]+(sp[0-9]+)?\b' | cut -d: -f2 | sort -V | tail -1 || true)
-          if [ -n "$latest" ]; then
-            echo "Latest released IDA from hcli: $latest"
-            export LATEST_RELEASED_IDA="$latest"
-          else
-            echo "hcli unavailable/unauthenticated; using merge_plugins.py default for LATEST_RELEASED_IDA"
-          fi
-
           uv run --script scripts/merge_plugins.py \
             --hcli plugin-repository.json \
             --tags tags.json \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,8 +82,30 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Merge plugins
+        env:
+          # Hex-Rays portal API key, used only to read the IDA download catalog
+          # (`hcli download --list-tags`) so idaVersions can be capped at the
+          # latest released IDA (EA-762). hcli authenticates from this env var
+          # automatically. If the secret is unset/invalid the derivation yields
+          # nothing and merge_plugins.py falls back to its built-in default —
+          # the build never fails on this.
+          HCLI_API_KEY: ${{ secrets.HCLI_API_KEY }}
+          HCLI_DISABLE_UPDATES: 1
         run: |
           mkdir -p ./public/plugins/
+
+          # EA-762: derive the latest released IDA from the hcli download catalog.
+          # Keeps only numeric ida-pro:X.Y[spN] tags (excludes betas / ida-pro:latest
+          # / OS-suffixed dupes) and takes the max.
+          latest=$(uvx --from ida-hcli hcli --disable-updates download --list-tags 2>/dev/null \
+            | grep -oE 'ida-pro:[0-9]+\.[0-9]+(sp[0-9]+)?\b' | cut -d: -f2 | sort -V | tail -1 || true)
+          if [ -n "$latest" ]; then
+            echo "Latest released IDA from hcli: $latest"
+            export LATEST_RELEASED_IDA="$latest"
+          else
+            echo "hcli unavailable/unauthenticated; using merge_plugins.py default for LATEST_RELEASED_IDA"
+          fi
+
           uv run --script scripts/merge_plugins.py \
             --hcli plugin-repository.json \
             --tags tags.json \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,9 +82,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Merge plugins
-        # EA-762: idaVersions are capped at the latest released IDA via
-        # merge_plugins.py's LATEST_RELEASED_IDA. Override with the env var when a
-        # new IDA ships (e.g. LATEST_RELEASED_IDA: "9.5") — no auth/secret needed.
         run: |
           mkdir -p ./public/plugins/
           uv run --script scripts/merge_plugins.py \

--- a/justfile
+++ b/justfile
@@ -29,35 +29,11 @@ collect-stars:
     uv run scripts/snapshot_github_repo_metadata.py plugin-repository.json public/plugins/
 
 
-# Print the latest released IDA version, derived from the hcli download catalog
-# (EA-762). Requires `hcli login`; prints nothing if hcli is unavailable or
-# unauthenticated, so callers can fall back to merge_plugins.py's default.
-# NOTE: confirm the tag format against real `hcli download --list-tags` output —
-# the regex excludes betas/rcs (ida-pro:9.5beta) and tolerates OS-suffixed tags
-# (ida-pro:9.2:armmac), keeping only numeric ida-pro:X.Y[spN].
-latest-ida:
-    #!/usr/bin/env bash
-    uvx --from ida-hcli hcli --disable-updates download --list-tags 2>/dev/null \
-        | grep -oE 'ida-pro:[0-9]+\.[0-9]+(sp[0-9]+)?\b' \
-        | cut -d: -f2 \
-        | sort -V \
-        | tail -1 || true
-
-
+# EA-762: idaVersions are capped at the latest released IDA via merge_plugins.py's
+# LATEST_RELEASED_IDA (default baked in; override with the env var when a new IDA
+# ships, e.g. `LATEST_RELEASED_IDA=9.5 just merge-plugins`).
 merge-plugins:
-    #!/usr/bin/env bash
-    set -euo pipefail
     mkdir -p ./public/plugins/
-    # EA-762: cap idaVersions at the latest released IDA. Derive it dynamically
-    # from the hcli download catalog; if hcli is unavailable/unauthenticated,
-    # fall back to the reviewed default baked into merge_plugins.py.
-    latest="$(just latest-ida)"
-    if [ -n "$latest" ]; then
-        echo "Latest released IDA from hcli: $latest"
-        export LATEST_RELEASED_IDA="$latest"
-    else
-        echo "hcli unavailable/unauthenticated; using merge_plugins.py default for LATEST_RELEASED_IDA"
-    fi
     uv run --script scripts/merge_plugins.py \
         --hcli plugin-repository.json \
         --tags tags.json \

--- a/justfile
+++ b/justfile
@@ -29,9 +29,6 @@ collect-stars:
     uv run scripts/snapshot_github_repo_metadata.py plugin-repository.json public/plugins/
 
 
-# EA-762: idaVersions are capped at the latest released IDA via merge_plugins.py's
-# LATEST_RELEASED_IDA (default baked in; override with the env var when a new IDA
-# ships, e.g. `LATEST_RELEASED_IDA=9.5 just merge-plugins`).
 merge-plugins:
     mkdir -p ./public/plugins/
     uv run --script scripts/merge_plugins.py \

--- a/justfile
+++ b/justfile
@@ -29,8 +29,35 @@ collect-stars:
     uv run scripts/snapshot_github_repo_metadata.py plugin-repository.json public/plugins/
 
 
+# Print the latest released IDA version, derived from the hcli download catalog
+# (EA-762). Requires `hcli login`; prints nothing if hcli is unavailable or
+# unauthenticated, so callers can fall back to merge_plugins.py's default.
+# NOTE: confirm the tag format against real `hcli download --list-tags` output —
+# the regex excludes betas/rcs (ida-pro:9.5beta) and tolerates OS-suffixed tags
+# (ida-pro:9.2:armmac), keeping only numeric ida-pro:X.Y[spN].
+latest-ida:
+    #!/usr/bin/env bash
+    uvx --from ida-hcli hcli --disable-updates download --list-tags 2>/dev/null \
+        | grep -oE 'ida-pro:[0-9]+\.[0-9]+(sp[0-9]+)?\b' \
+        | cut -d: -f2 \
+        | sort -V \
+        | tail -1 || true
+
+
 merge-plugins:
+    #!/usr/bin/env bash
+    set -euo pipefail
     mkdir -p ./public/plugins/
+    # EA-762: cap idaVersions at the latest released IDA. Derive it dynamically
+    # from the hcli download catalog; if hcli is unavailable/unauthenticated,
+    # fall back to the reviewed default baked into merge_plugins.py.
+    latest="$(just latest-ida)"
+    if [ -n "$latest" ]; then
+        echo "Latest released IDA from hcli: $latest"
+        export LATEST_RELEASED_IDA="$latest"
+    else
+        echo "hcli unavailable/unauthenticated; using merge_plugins.py default for LATEST_RELEASED_IDA"
+    fi
     uv run --script scripts/merge_plugins.py \
         --hcli plugin-repository.json \
         --tags tags.json \

--- a/scripts/merge_plugins.py
+++ b/scripts/merge_plugins.py
@@ -32,6 +32,7 @@
 import argparse
 import json
 import logging
+import os
 import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
@@ -165,6 +166,38 @@ def prettify_ida_versions(ida_versions: list[str]) -> list[str]:
     if len(ida_versions) == 1 or first == last:
         return [first]
     return [f"{first} to {last}"]
+
+
+# The latest publicly released IDA version. The upstream HCLI index expands
+# open-ended specs like ">=9.0" into a concrete list that includes forward-
+# looking placeholders (e.g. "10.0") not yet released (EA-762). cap_ida_versions
+# trims the list here so plugin pages never advertise an unreleased IDA.
+#
+# There is no machine-readable "latest released IDA" feed to derive this from
+# (Hex-Rays only publishes HTML release notes), so it's a reviewed default that
+# CI can override without a code change when a new IDA ships:
+#   LATEST_RELEASED_IDA=9.5 just merge-plugins
+_DEFAULT_LATEST_RELEASED_IDA = "9.4"
+LATEST_RELEASED_IDA = os.environ.get("LATEST_RELEASED_IDA", _DEFAULT_LATEST_RELEASED_IDA)
+
+
+def _ida_version_key(version: str) -> tuple[int, int, int, int] | None:
+    """Parse "9.0", "9.0sp1", "6.95", "9.0.0" into a sortable key, or None."""
+    m = re.fullmatch(r"(\d+)\.(\d+)(?:\.(\d+))?(?:sp(\d+))?", version.strip())
+    if not m:
+        return None
+    return int(m.group(1)), int(m.group(2)), int(m.group(3) or 0), int(m.group(4) or 0)
+
+
+def cap_ida_versions(ida_versions: list[str], latest: str = LATEST_RELEASED_IDA) -> list[str]:
+    """Drop versions newer than ``latest``; keep unparseable entries untouched."""
+    cap = _ida_version_key(latest)
+    if cap is None:
+        return list(ida_versions)
+    return [
+        v for v in ida_versions
+        if (key := _ida_version_key(v)) is None or key <= cap
+    ]
 
 
 # ─── Logo URL resolution ──────────────────────────────────────────────────────
@@ -355,7 +388,8 @@ def transform_hcli_plugin(hcli_plugin: dict, github_meta: dict, tags_map: dict, 
         normalized_authors = [Author(login=owner, name=owner, email="", repository_owner=owner, derivedFromName=False)]
 
     # Versions
-    prettified = prettify_ida_versions(plugin_meta.get("idaVersions") or [])
+    ida_versions = cap_ida_versions(plugin_meta.get("idaVersions") or [])
+    prettified = prettify_ida_versions(ida_versions)
 
     # Tags: from A (metadata.tags) + C (tags.json) + auto-tag plugin_manager_ready
     # A has the full tag set (contest years, placements, award_winning, favourite, etc.)
@@ -380,7 +414,7 @@ def transform_hcli_plugin(hcli_plugin: dict, github_meta: dict, tags_map: dict, 
                     keywords=plugin_meta.get("keywords") or [],
                     absoluteLogoUrl=absolute_logo_url,
                     version=plugin_meta.get("version") or latest_key,
-                    idaVersions=plugin_meta.get("idaVersions") or [],
+                    idaVersions=ida_versions,
                     license=plugin_meta.get("license"),
                 ),
             ),
@@ -458,6 +492,7 @@ def transform_legacy_plugin(api_plugin: dict, github_meta: dict, tags_map: dict,
         raw_ida_versions = raw_plugin.get("idaVersions") or []
         if isinstance(raw_ida_versions, str):
             raw_ida_versions = [raw_ida_versions]
+        raw_ida_versions = cap_ida_versions(raw_ida_versions)
         idaplugin_json = IdaPluginJson(
             plugin=PluginInfo(
                 name=raw_plugin.get("name") or plugin_name,
@@ -670,6 +705,7 @@ def do_merge(
             legacy_count += 1
 
     logger.info("Merged: %d HCLI + %d legacy = %d total plugins", hcli_count, legacy_count, len(output_plugins))
+    logger.info("IDA version cap: idaVersions trimmed to <= %s (latest released)", LATEST_RELEASED_IDA)
 
     # Verify no duplicates
     slugs = [p.slug for p in output_plugins]


### PR DESCRIPTION
https://hex-rays.atlassian.net/browse/EA-762

The merger's known-versions table contains 10.0 as a forward-looking placeholder, and >=X.Y is expanded greedily against the full table without a release-cap. 

What this PR does:
1. Remove unreleased versions from the table until each one actually ships.
2. Keep the table as-is but cap the expansion at a LATEST_RELEASED_IDA constant that is bumped manually only when a new IDA release goes out.